### PR TITLE
set blog end position correctly

### DIFF
--- a/pages/blog/post/[slug].tsx
+++ b/pages/blog/post/[slug].tsx
@@ -133,7 +133,9 @@ const PostPage = ({
 
   useEffect(() => {
     setEndPosition(blogBody.current?.offsetHeight || 0);
-  }, [blogBody]);
+    // recalculate end position when blog sections are processed
+    // because at that point the page height is finalized
+  }, [postSections]);
 
   useEffect(() => {
     setPostRaw(post.richcontent.raw.children);


### PR DESCRIPTION
set the blog end position when the blog post sections are processed
since at that time we fully render all sections of the blog page.
https://www.loom.com/share/f66256a7025c419385a3fbf4d8ac4cc2