### PR TITLE
align sign in/up buttons with rest of menu

### DIFF
--- a/components/Home/CompaniesReel/CompaniesReel.tsx
+++ b/components/Home/CompaniesReel/CompaniesReel.tsx
@@ -34,7 +34,7 @@ export const CompaniesReel = () => {
             src={Hightouch}
             alt="Hightouch"
             className={styles.scaleHeight}
-            style={{ transform: 'scale(1.4)' }}
+            style={{ transform: 'scale(1.1)' }}
           />
           <Image src={Basedash} alt="Basedash" />
           <Image src={Impira} alt="Impira" className={styles.scaleHeight} />

--- a/components/common/Navbar/Navbar.module.scss
+++ b/components/common/Navbar/Navbar.module.scss
@@ -213,20 +213,20 @@
   }
 
   .mobileMenu {
+    align-items: center;
+    background-color: var(--color-primary-200);
     border-top: 1px solid rgb(255, 255, 255, 0.32);
-    position: absolute;
-    top: 64px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-medium);
+    height: calc(100vh - 60px);
+    justify-content: flex-start;
     left: 0;
     padding: var(--size-medium) var(--size-medium) var(--size-xLarge)
       var(--size-medium);
-    background-color: var(--color-primary-200);
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
+    position: absolute;
+    top: 64px;
     width: 100%;
-    height: calc(100vh - 60px);
-    gap: var(--size-medium);
 
     li {
       width: 100%;


### PR DESCRIPTION
On mobile, display sign-in/sign-up buttons right after the last entry of the navigation menu.
In the companies reel, fix Hightouch logo scaling on mobile.

![image](https://user-images.githubusercontent.com/1351531/182253673-c14af6f1-677f-40ca-bceb-7e445b82451c.png)

![image](https://user-images.githubusercontent.com/1351531/182253703-2add4ef0-2bca-47e8-a353-13d9c6a91f3a.png)
