### PR TITLE
Tweaks to FAQ dropdown icons

### DIFF
--- a/components/Pricing/Pricing.module.scss
+++ b/components/Pricing/Pricing.module.scss
@@ -286,6 +286,7 @@
   height: 32px;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
   justify-content: center;
   font-size: 8px;
   transition-duration: 0.2s;


### PR DESCRIPTION
* Fixes an issue where circles became ovals on small viewport sizes
* Prevents the chevron from being clipped on smaller viewports
* Adds some margin to give space between text and icons (requested by Clint)

If click testing on iPhone, make sure to hit the Vercel link from your phone rather than the simulator. That's the only place I could repro the original issue.