### PR TITLE
Clean up spacing on CTA

### DIFF
--- a/components/Home/Home.module.scss
+++ b/components/Home/Home.module.scss
@@ -648,6 +648,10 @@
   overflow: hidden;
   margin: auto auto var(--size-xLarge);
 
+  .ctaTitle {
+    margin-top: 0 !important;
+  }
+
   .ctaContainer {
     width: 100%;
     padding: calc(32 * var(--space-unit)) 0;

--- a/components/Home/Home.module.scss.d.ts
+++ b/components/Home/Home.module.scss.d.ts
@@ -30,6 +30,7 @@ export const companies: string;
 export const companyLogo: string;
 export const ctaBg: string;
 export const ctaContainer: string;
+export const ctaTitle: string;
 export const customerCopy: string;
 export const customerReel: string;
 export const featureContainer: string;

--- a/components/common/CallToAction/CallToAction.tsx
+++ b/components/common/CallToAction/CallToAction.tsx
@@ -18,7 +18,7 @@ export const CallToAction = () => {
         <div className={styles.sectionSubtitle}>
           <Typography type="outline">Try Highlight Today</Typography>
         </div>
-        <h2>
+        <h2 className={styles.ctaTitle}>
           Get the <span className={styles.highlightedText}>visibility</span> you
           need
         </h2>


### PR DESCRIPTION
Removes the margin we apply to all headings on blog posts for the CTA, fixing a bug in the spacing of the CTA content.

<img width="890" alt="Screen Shot 2022-08-03 at 8 45 21 AM" src="https://user-images.githubusercontent.com/308182/182611051-12ba4e17-95e6-40f7-86e8-075685573bc9.png">
