### PR TITLE
Hide scrollbars on code snippets

### DIFF
--- a/components/Home/Home.module.scss
+++ b/components/Home/Home.module.scss
@@ -1,3 +1,5 @@
+@import 'styles/mixins';
+
 .bgPosition {
   position: absolute;
   z-index: -1;
@@ -528,13 +530,7 @@
   overflow: scroll;
   position: relative;
   width: 100%;
-
-  // Hides the scrollbar. Requires different properties for certain browsers.
-  -ms-overflow-style: none; // IE
-  scrollbar-width: none; // Firefox
-  &::-webkit-scrollbar {
-    display: none; // Everything else
-  }
+  @include hide-scrollbar;
 
   .slideTrack {
     transition: all 0.1s linear;
@@ -634,6 +630,11 @@
     padding: var(--size-large) var(--size-large) calc(20 * var(--space-unit));
     overflow: scroll;
     position: relative;
+    @include hide-scrollbar;
+
+    > span {
+      @include hide-scrollbar;
+    }
 
     .codeSnippetCopy {
       position: absolute;

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -1,0 +1,14 @@
+// from https://gist.github.com/pandauxstudio/d91860cbdfc2d12526ce04f8c4eb829b
+@mixin hide-scrollbar {
+  // There is a CSS rule that can hide scrollbars in IE 10+.
+  -ms-overflow-style: none;
+
+  // There used to be a CSS rule that could hide scrollbars in Firefox, but it has since been deprecated.
+  scrollbar-width: none;
+
+  // https://blogs.msdn.microsoft.com/kurlak/2013/11/03/hiding-vertical-scrollbars-with-pure-css-in-chrome-ie-6-firefox-opera-and-safari/
+  // There is a CSS rule that can hide scrollbars in Webkit-based browsers (Chrome and Safari).
+  &::-webkit-scrollbar {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Fixes an issue where scrollbars are shown on code snippets. We had only noticed this so far in Chrome on Linux.