### PR TITLE
Add open graph tags for social previews

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import '../styles/public.css';
 import type { AppProps } from 'next/app';
 import Script from 'next/script';
 import MetaImage from '../public/images/meta-image.jpg';
+import Head from 'next/head';
 
 Router.events.on('routeChangeStart', nProgress.start);
 Router.events.on('routeChangeError', nProgress.done);
@@ -31,24 +32,36 @@ function MyApp({ Component, pageProps }: AppProps) {
             gtag('config', 'G-P2T64QS94S');
             `}
       </Script>
-      {/* Twitter */}
-      <meta name="twitter:card" content="summary_large_image" key="twcard" />
-      <meta name="twitter:site" content="https://www.highlight.io" />
-      <meta name="twitter:creator" content="@highlightrun" />
+      <Head>
+        <title>
+          Highlight: The Ultimate Debugging Tool For Fast-Moving Teams
+        </title>
 
-      {/* Open Graph */}
-      <meta property="og:url" content={'highlight.io'} key="ogurl" />
-      <meta property="og:image" content={MetaImage.src} key="ogimage" />
-      <meta property="og:site_name" content={'Highlight'} key="ogsitename" />
-      <meta property="og:title" content={'Highlight: Homepage'} key="ogtitle" />
-      <meta
-        property="og:description"
-        content={
-          'Highlight removes the mystery of debugging through automatic session replay, error stack tracing, collaboration, and search. Never debug in the dark again.'
-        }
-        key="ogdesc"
-      />
-      <link rel="preconnect" href="https://fonts.googleapis.com"></link>
+        {/* Twitter */}
+        <meta name="twitter:card" content="summary_large_image" key="twcard" />
+        <meta name="twitter:site" content="https://www.highlight.io" />
+        <meta name="twitter:creator" content="@highlightrun" />
+
+        {/* Open Graph */}
+        <meta property="og:url" content="highlight.io" key="ogurl" />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={MetaImage.src} key="ogimage" />
+        <meta property="og:site_name" content="Highlight" key="ogsitename" />
+        <meta
+          property="og:title"
+          content="Highlight: The Ultimate Debugging Tool For Fast-Moving Teams"
+          key="ogtitle"
+        />
+        <meta
+          property="og:description"
+          content="Highlight removes the mystery of debugging through automatic session replay, error stack tracing, collaboration, and search. Never debug in the dark again."
+          key="ogdesc"
+        />
+
+        <link rel="preconnect" href="https://fonts.googleapis.com"></link>
+
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
       <Component {...pageProps} />
     </>
   );

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -98,6 +98,17 @@ const Blog = ({
           name="description"
           content="Get debugging best practices, read customer stories, and get general dev tips. Learn to stop debugging in the dark with Highlight's blog and featured articles."
         />
+
+        <meta
+          property="og:title"
+          content="Debugging Blog: Best Practices From The Highlight Team"
+          key="ogtitle"
+        />
+        <meta
+          property="og:description"
+          content="Get debugging best practices, read customer stories, and get general dev tips. Learn to stop debugging in the dark with Highlight's blog and featured articles."
+          key="ogdesc"
+        />
       </Head>
       <Navbar />
       <main>

--- a/pages/blog/post/[slug].tsx
+++ b/pages/blog/post/[slug].tsx
@@ -251,6 +251,14 @@ const PostPage = ({
           name="description"
           content={post.metaDescription || post.description}
         />
+
+        <meta property="og:image" content={post.image.url} key="ogimage" />
+        <meta property="og:title" content={post.metaTitle} key="ogtitle" />
+        <meta
+          property="og:description"
+          content={post.metaDescription}
+          key="ogdesc"
+        />
       </Head>
       <BlogNavbar title={post.title} endPosition={endPosition} />
       <main ref={blogBody} className={styles.mainBlogPadding}>

--- a/pages/changelog/[slug].tsx
+++ b/pages/changelog/[slug].tsx
@@ -66,7 +66,7 @@ const ChangelogPage = ({ changelog }: { changelog: any }) => {
     <>
       <Head>
         <title>{changelog.title}</title>
-        <meta name="description" content="Stop debugging in the dark. " />
+        <meta property="og:title" content={changelog.title} key="ogtitle" />
       </Head>
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>

--- a/pages/comments/index.tsx
+++ b/pages/comments/index.tsx
@@ -21,7 +21,12 @@ const Comments: NextPage = () => {
     <div>
       <Head>
         <title>Comments - Highlight</title>
-        <meta name="description" content="Stop debugging in the dark. " />
+
+        <meta
+          property="og:title"
+          content="Comments - Highlight"
+          key="ogtitle"
+        />
       </Head>
       <div className={styles.bgPosition}>
         <div className={styles.purpleDiv}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -181,16 +181,6 @@ const Home: NextPage = () => {
 
   return (
     <div>
-      <Head>
-        <title>
-          Highlight: The Ultimate Debugging Tool For Fast-Moving Teams
-        </title>
-        <meta
-          name="description"
-          content="Highlight removes the mystery of debugging through automatic session replay, error stack tracing, collaboration, and search. Never debug in the dark again."
-        />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
       <Navbar />
       <main>
         <Section className={styles.heroVideoWrapper}>

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -232,6 +232,18 @@ const Pricing: NextPage = () => {
           name="description"
           content="Highlight's developer friendly pricing makes sure any team can afford to get the visibility into bugs they need. See plans, features, FAQs and more here:"
         />
+
+        <meta
+          property="og:title"
+          content="Highlight: Plans And Pricing For Any Team. Get Started Free."
+          key="ogtitle"
+        />
+        <meta
+          property="og:description"
+          content="Highlight's developer friendly pricing makes sure any team can afford to get the visibility into bugs they need. See plans, features, FAQs and more here:"
+          key="ogdesc"
+        />
+
         <script type="application/ld+json">
           {`{
             "@context": "https://schema.org",

--- a/pages/privacy/index.tsx
+++ b/pages/privacy/index.tsx
@@ -12,8 +12,18 @@ const Privacy = () => {
   return (
     <>
       <Head>
-        <title>Privacy Policy</title>
+        <title>Highlight: Privacy Policy</title>
         <meta name="description" content="Highlight privacy policy" />
+        <meta
+          property="og:title"
+          content="Highlight: Privacy Policy"
+          key="ogtitle"
+        />
+        <meta
+          property="og:description"
+          content="Highlight privacy policy"
+          key="ogdesc"
+        />
       </Head>
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>

--- a/pages/terms/index.tsx
+++ b/pages/terms/index.tsx
@@ -13,8 +13,19 @@ const Terms = () => {
   return (
     <>
       <Head>
-        <title>Terms of Service</title>
-        <meta name="description" content="Highlight terms of service" />
+        <title>Highlight: Terms of Service</title>
+        <meta name="description" content="Highlight: Terms of Service" />
+
+        <meta
+          property="og:title"
+          content="Highlight: Terms of Service"
+          key="ogtitle"
+        />
+        <meta
+          property="og:description"
+          content="Highlight: Terms of Service"
+          key="ogdesc"
+        />
       </Head>
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>


### PR DESCRIPTION
Adds Open Graph tags for social previews. Also refactors `_app.tsx` to use `<Head>` for rendering the defaults in the `<head>` of the document.