### PR TITLE
Fix incorrect spacing of collaboration section on mobile

### DIFF
--- a/components/Home/Home.module.scss
+++ b/components/Home/Home.module.scss
@@ -80,7 +80,6 @@
   position: absolute;
   right: -200px;
   top: 0;
-  transform: scaleX(-1);
   width: 280px;
 }
 


### PR DESCRIPTION
CSS rules are being applied in a different order in production vs dev causing different rules to take precedence. This PR increases the specificity of a couple rules to fix the issue.

Also includes a small fix to flip the bug in the footer CTA, which was a request from Clint in Slack.