### PR TITLE
Remove gradient on terms and privacy pages

### DIFF
--- a/pages/privacy/index.tsx
+++ b/pages/privacy/index.tsx
@@ -25,14 +25,6 @@ const Privacy = () => {
           key="ogdesc"
         />
       </Head>
-      <div className={homeStyles.bgPosition}>
-        <div className={homeStyles.purpleDiv}>
-          <Image src={PurpleGradient} alt="" />
-        </div>
-        <div className={homeStyles.blueDiv}>
-          <Image src={BlueGradient} alt="" />
-        </div>
-      </div>
       <Navbar />
       <main>
         <Section>

--- a/pages/terms/index.tsx
+++ b/pages/terms/index.tsx
@@ -27,14 +27,6 @@ const Terms = () => {
           key="ogdesc"
         />
       </Head>
-      <div className={homeStyles.bgPosition}>
-        <div className={homeStyles.purpleDiv}>
-          <Image src={PurpleGradient} alt="" />
-        </div>
-        <div className={homeStyles.blueDiv}>
-          <Image src={BlueGradient} alt="" />
-        </div>
-      </div>
       <Navbar />
       <main>
         <Section>


### PR DESCRIPTION
Removes an unwanted gradient on `/terms` and `/privacy`. The styles could not be deleted yet because they are still used some pages.