### PR TITLE
use meta image urls for blog posts

### DIFF
--- a/components/Blog/BlogPost/BlogPost.tsx
+++ b/components/Blog/BlogPost/BlogPost.tsx
@@ -21,6 +21,9 @@ export interface Post {
   image: {
     url: string;
   };
+  metaImage: {
+    url: string;
+  };
   title: string;
   metaTitle?: string;
   publishedAt: string;

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -76,6 +76,9 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         image {
           url
         }
+        metaImage {
+          url
+        }
         description
         metaDescription
         publishedAt
@@ -256,7 +259,7 @@ const PostPage = ({
         <Meta
           title={post.metaTitle || post.title}
           description={post.metaDescription || post.description}
-          absoluteImageUrl={post.image.url}
+          absoluteImageUrl={post.metaImage.url}
         />
       </Head>
       <BlogNavbar title={post.title} endPosition={endPosition} />


### PR DESCRIPTION
Adds a new hygraph `metaImage` artifact for blog posts that is set in the meta tags.