### PR TITLE
refactor head tags to avoid duplicate meta tags

### DIFF
--- a/components/common/Head/Meta.tsx
+++ b/components/common/Head/Meta.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import MetaImage from '../../../public/images/meta-image.jpg';
 export const Meta = ({
   title,
@@ -12,21 +13,22 @@ export const Meta = ({
     absoluteImageUrl ||
     `https://${process.env.NEXT_PUBLIC_VERCEL_URL}${MetaImage.src}`;
   return (
-    <>
-      <meta name="description" content={description} />
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} key="description" />
       {/* Twitter */}
       <meta name="twitter:card" content="summary_large_image" key="twcard" />
-      <meta name="twitter:site" content="@highlightrun" />
-      <meta name="twitter:creator" content="@highlightrun" />
+      <meta name="twitter:site" content="@highlightrun" key="twsite" />
+      <meta name="twitter:creator" content="@highlightrun" key="twcreator" />
       <meta name="twitter:image" content={img} key="twimage" />
       <meta name="twitter:title" content={title} key="twtitle" />
       {/* Open Graph */}
       <meta property="og:url" content="highlight.io" key="ogurl" />
-      <meta property="og:type" content="website" />
+      <meta property="og:type" content="website" key="ogtype" />
       <meta property="og:image" content={img} key="ogimage" />
       <meta property="og:site_name" content="Highlight" key="ogsitename" />
       <meta property="og:title" content={title} key="ogtitle" />
       <meta property="og:description" content={description} key="ogdesc" />
-    </>
+    </Head>
   );
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,16 +37,16 @@ function MyApp({ Component, pageProps }: AppProps) {
         <title>
           Highlight: The Ultimate Debugging Tool For Fast-Moving Teams
         </title>
-        <Meta
-          title="Highlight: The Ultimate Debugging Tool For Fast-Moving Teams"
-          description="Highlight removes the mystery of debugging through automatic session replay, error stack tracing, collaboration, and search. Never debug in the dark again."
-          absoluteImageUrl={`https://${process.env.NEXT_PUBLIC_VERCEL_URL}${MetaImage.src}`}
-        />
 
         <link rel="preconnect" href="https://fonts.googleapis.com"></link>
 
         <link rel="icon" href="/favicon.ico" />
       </Head>
+      <Meta
+        title="Highlight: The Ultimate Debugging Tool For Fast-Moving Teams"
+        description="Highlight removes the mystery of debugging through automatic session replay, error stack tracing, collaboration, and search. Never debug in the dark again."
+        absoluteImageUrl={`https://${process.env.NEXT_PUBLIC_VERCEL_URL}${MetaImage.src}`}
+      />
       <Component {...pageProps} />
     </>
   );

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Head from 'next/head';
 import homeStyles from '../../components/Home/Home.module.scss';
 import styles from '../../components/Blog/Blog.module.scss';
 import { Section } from '../../components/common/Section/Section';
@@ -245,14 +244,11 @@ const PostPage = ({
 
   return (
     <>
-      <Head>
-        <title>{post.metaTitle || post.title}</title>
-        <Meta
-          title={post.metaTitle || post.title}
-          description={post.metaDescription || post.description}
-          absoluteImageUrl={post.metaImage.url}
-        />
-      </Head>
+      <Meta
+        title={post.metaTitle || post.title}
+        description={post.metaDescription || post.description}
+        absoluteImageUrl={post.metaImage.url}
+      />
       <BlogNavbar title={post.title} endPosition={endPosition} />
       <main ref={blogBody} className={styles.mainBlogPadding}>
         <Section>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import styles from '../../components/Blog/Blog.module.scss';
 import Navbar from '../../components/common/Navbar/Navbar';
 import Footer from '../../components/common/Footer/Footer';
@@ -89,13 +88,10 @@ const Blog = ({
 
   return (
     <>
-      <Head>
-        <title>Debugging Blog: Best Practices From The Highlight Team</title>
-        <Meta
-          title="Debugging Blog: Best Practices From The Highlight Team"
-          description="Get debugging best practices, read customer stories, and get general dev tips. Learn to stop debugging in the dark with Highlight's blog and featured articles."
-        />
-      </Head>
+      <Meta
+        title="Debugging Blog: Best Practices From The Highlight Team"
+        description="Get debugging best practices, read customer stories, and get general dev tips. Learn to stop debugging in the dark with Highlight's blog and featured articles."
+      />
       <Navbar />
       <main>
         <div className={styles.blogContainer}>

--- a/pages/careers/[slug].tsx
+++ b/pages/careers/[slug].tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Head from 'next/head';
 import BlueGradient from '../../public/images/bg_blue_gradient.svg';
 import PurpleGradient from '../../public/images/bg_purple_gradient.svg';
 import homeStyles from '../../components/Home/Home.module.scss';
@@ -12,6 +11,7 @@ import { GetStaticPaths, GetStaticProps } from 'next/types';
 import { FooterCallToAction } from '../../components/common/CallToAction/FooterCallToAction';
 import { OPEN_ROLES } from '../../components/Careers/careers';
 import ReactMarkdown from 'react-markdown';
+import { Meta } from '../../components/common/Head/Meta';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
@@ -42,10 +42,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 const CareerPage = ({ role }: { role: any }) => {
   return (
     <>
-      <Head>
-        <title>Highlight Blog</title>
-        <meta name="description" content="Stop debugging in the dark. " />
-      </Head>
+      <Meta
+        title="Highlight Careers: Joining the Team"
+        description="Stop debugging in the dark. Join the team that makes it happen!"
+      />
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>
           <Image src={PurpleGradient} alt="" />

--- a/pages/careers/index.tsx
+++ b/pages/careers/index.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Head from 'next/head';
 import BlueGradient from '../../public/images/bg_blue_gradient.svg';
 import PurpleGradient from '../../public/images/bg_purple_gradient.svg';
 import homeStyles from '../../components/Home/Home.module.scss';
@@ -10,17 +9,15 @@ import Footer from '../../components/common/Footer/Footer';
 import { FooterCallToAction } from '../../components/common/CallToAction/FooterCallToAction';
 import { OPEN_ROLES } from '../../components/Careers/careers';
 import Link from 'next/link';
+import { Meta } from '../../components/common/Head/Meta';
 
 const Careers = () => {
   return (
     <>
-      <Head>
-        <title>Careers At Highlight: Build The Best Debugging Tool Ever</title>
-        <meta
-          name="description"
-          content="We're building a platform for debugging apps with extremely high precision, with the goal of helping teams better understand how their app behaves. See careers:"
-        />
-      </Head>
+      <Meta
+        title="Careers At Highlight: Build The Best Debugging Tool Ever"
+        description="We're building a platform for debugging apps with extremely high precision, with the goal of helping teams better understand how their app behaves. See careers:"
+      />
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>
           <Image src={PurpleGradient} alt="" />

--- a/pages/changelog/[slug].tsx
+++ b/pages/changelog/[slug].tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Head from 'next/head';
 import BlueGradient from '../../public/images/bg_blue_gradient.svg';
 import PurpleGradient from '../../public/images/bg_purple_gradient.svg';
 import homeStyles from '../../components/Home/Home.module.scss';
@@ -65,10 +64,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 const ChangelogPage = ({ changelog }: { changelog: any }) => {
   return (
     <>
-      <Head>
-        <title>{changelog.title}</title>
-        <Meta title={changelog.title} description={changelog.title} />
-      </Head>
+      <Meta title={changelog.title} description={changelog.title} />
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>
           <Image src={PurpleGradient} alt="" />

--- a/pages/changelog/index.tsx
+++ b/pages/changelog/index.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import Head from 'next/head';
 import BlueGradient from '../../public/images/bg_blue_gradient.svg';
 import PurpleGradient from '../../public/images/bg_purple_gradient.svg';
 import homeStyles from '../../components/Home/Home.module.scss';
@@ -17,6 +16,7 @@ import {
   Entry,
 } from '../../components/Changelog/ChangelogEntry/ChangelogEntry';
 import { GetStaticProps } from 'next/types';
+import { Meta } from '../../components/common/Head/Meta';
 
 const ITEMS_PER_PAGE = 25;
 
@@ -57,10 +57,10 @@ const Changelog = ({ changelogs }: { changelogs: Array<never> }) => {
 
   return (
     <>
-      <Head>
-        <title>Highlight Changelog</title>
-        <meta name="description" content="Stop debugging in the dark. " />
-      </Head>
+      <Meta
+        title={'Highlight Changelog'}
+        description={'Stop debugging in the dark.'}
+      />
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>
           <Image src={PurpleGradient} alt="" />

--- a/pages/comments/index.tsx
+++ b/pages/comments/index.tsx
@@ -1,5 +1,4 @@
 import type { NextPage } from 'next';
-import Head from 'next/head';
 import Image from 'next/image';
 import React from 'react';
 import { PrimaryButton } from '../../components/common/Buttons/PrimaryButton';
@@ -20,14 +19,10 @@ import { Meta } from '../../components/common/Head/Meta';
 const Comments: NextPage = () => {
   return (
     <div>
-      <Head>
-        <title>Comments - Highlight</title>
-
-        <Meta
-          title="Comments - Highlight"
-          description="Comments by Highlight"
-        />
-      </Head>
+      <Meta
+        title={'Comments - Highlight'}
+        description={'Comments by Highlight'}
+      />
       <div className={styles.bgPosition}>
         <div className={styles.purpleDiv}>
           <Image src={PurpleGradient} alt="" />

--- a/pages/customers/index.tsx
+++ b/pages/customers/index.tsx
@@ -1,6 +1,5 @@
 import { GetStaticProps, NextPage } from 'next';
 import Image from 'next/image';
-import Head from 'next/head';
 import BlueGradient from '../../public/images/bg_blue_gradient.svg';
 import PurpleGradient from '../../public/images/bg_purple_gradient.svg';
 import homeStyles from '../../components/Home/Home.module.scss';
@@ -11,6 +10,7 @@ import Footer from '../../components/common/Footer/Footer';
 import { CUSTOMER_REVIEWS } from '../../components/Customers/Customers';
 import { CustomerCard } from '../../components/Customers/CustomerCard/CustomerCard';
 import { FooterCallToAction } from '../../components/common/CallToAction/FooterCallToAction';
+import { Meta } from '../../components/common/Head/Meta';
 
 // Hides the page in production and renders it in dev. More info:
 // https://linear.app/highlight/issue/HIG-2510/temporarily-update-customers-functionality
@@ -25,13 +25,12 @@ export const getStaticProps: GetStaticProps = async () => {
 const Customers: NextPage = () => {
   return (
     <>
-      <Head>
-        <title>Highlight: See Customer Stories And Case Studies.</title>
-        <meta
-          name="description"
-          content="Highlight powers forward-thinking companies. Don't take our word for it. Learn straight from the people we help. Here's what our customers have to say:"
-        />
-      </Head>
+      <Meta
+        title={'Highlight: See Customer Stories And Case Studies.'}
+        description={
+          "Highlight powers forward-thinking companies. Don't take our word for it. Learn straight from the people we help. Here's what our customers have to say:"
+        }
+      />
       <div className={homeStyles.bgPosition}>
         <div className={homeStyles.purpleDiv}>
           <Image src={PurpleGradient} alt="" />

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -229,11 +229,6 @@ const Pricing: NextPage = () => {
         <title>
           Highlight: Plans And Pricing For Any Team. Get Started Free.
         </title>
-        <Meta
-          title="Highlight: Plans And Pricing For Any Team. Get Started Free."
-          description="Highlight's developer friendly pricing makes sure any team can afford to get the visibility into bugs they need. See plans, features, FAQs and more here:"
-        />
-
         <script type="application/ld+json">
           {`{
             "@context": "https://schema.org",
@@ -252,6 +247,10 @@ const Pricing: NextPage = () => {
           }`}
         </script>
       </Head>
+      <Meta
+        title="Highlight: Plans And Pricing For Any Team. Get Started Free."
+        description="Highlight's developer friendly pricing makes sure any team can afford to get the visibility into bugs they need. See plans, features, FAQs and more here:"
+      />
       <Navbar />
       <main>
         <Section className={styles.titleSection}>

--- a/pages/privacy/index.tsx
+++ b/pages/privacy/index.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import homeStyles from '../../components/Home/Home.module.scss';
 import Navbar from '../../components/common/Navbar/Navbar';
 import { Section } from '../../components/common/Section/Section';
@@ -9,13 +8,10 @@ import { Meta } from '../../components/common/Head/Meta';
 const Privacy = () => {
   return (
     <>
-      <Head>
-        <title>Highlight: Privacy Policy</title>
-        <Meta
-          title={'Highlight: Privacy Policy'}
-          description={'Highlight privacy policy'}
-        />
-      </Head>
+      <Meta
+        title={'Highlight: Privacy Policy'}
+        description={'Highlight privacy policy'}
+      />
       <Navbar />
       <main>
         <Section>

--- a/pages/terms/index.tsx
+++ b/pages/terms/index.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import homeStyles from '../../components/Home/Home.module.scss';
 import Navbar from '../../components/common/Navbar/Navbar';
 import { Section } from '../../components/common/Section/Section';
@@ -10,13 +9,10 @@ import { Meta } from '../../components/common/Head/Meta';
 const Terms = () => {
   return (
     <>
-      <Head>
-        <title>Highlight: Terms of Service</title>
-        <Meta
-          title={'Highlight: Terms of Service'}
-          description={'Highlight: Terms of Service'}
-        />
-      </Head>
+      <Meta
+        title={'Highlight: Terms of Service'}
+        description={'Highlight: Terms of Service'}
+      />
       <Navbar />
       <main>
         <Section>


### PR DESCRIPTION
ensure multiple meta tags do not incorrectly overwrite.
nextjs `Head` [component](https://nextjs.org/docs/api-reference/next/head) will use the last `meta` tags of the same key, but only
when they are in a singly-nested `Head` component.
ensure we do not have nested `Head` components so that this works correctly.

The regression in meta tag replacement occurred due to an optimization for more server-side rendering in the blog.
Before #64 , the meta tags were correctly replaced due to their rendering in javascript.

Testing: validated all pages with https://www.opengraph.xyz/
![image](https://user-images.githubusercontent.com/1351531/184432914-fed52be9-5974-47e9-8b36-a6f64b8c9924.png)
