### PR TITLE
update image styling on blog

### DIFF
--- a/components/Blog/Blog.module.scss
+++ b/components/Blog/Blog.module.scss
@@ -359,6 +359,14 @@
   }
 }
 
+.blogImageContainer {
+  padding: 12px 0;
+}
+
+.blogImage {
+  border-radius: 6px;
+}
+
 // Custom font styles for blog-specific text!!!
 
 h2.blogText + h3.blogText {

--- a/components/Blog/Blog.module.scss.d.ts
+++ b/components/Blog/Blog.module.scss.d.ts
@@ -3,6 +3,8 @@ export const authorDetails: string;
 export const authorDiv: string;
 export const avatar: string;
 export const blogContainer: string;
+export const blogImage: string;
+export const blogImageContainer: string;
 export const blogPost: string;
 export const blogPostSmall: string;
 export const blogText: string;

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -264,12 +264,15 @@ const PostSection = ({ p }: { p: PostSection; idx: number }) => {
           h6: getBlogTypographyRenderer('h6'),
           p: getBlogTypographyRenderer('p'),
           img: (props) => (
-            <Image
-              src={props.src || ''}
-              alt={props.altText}
-              width={props.width}
-              height={props.height}
-            />
+            <div className={styles.blogImageContainer}>
+              <Image
+                className={styles.blogImage}
+                src={props.src || ''}
+                alt={props.altText}
+                width={props.width}
+                height={props.height}
+              />
+            </div>
           ),
         }}
       />


### PR DESCRIPTION
update padding between image and adjacent text to be
consistent with the padding between paragraphs.
set an image border-radius of 6px

![image](https://user-images.githubusercontent.com/1351531/185012675-610cd45a-b2a4-40a9-b9ac-9f087a64902c.png)
