### PR TITLE
hide unlisted blog posts from the blog list

### DIFF
--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -28,7 +28,10 @@ export const graphcms = new GraphQLClient(
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const QUERY = gql`
     query GetPosts($tag: [String!]) {
-      posts(orderBy: publishedAt_DESC, where: { tags_contains_all: $tag }) {
+      posts(
+        orderBy: publishedAt_DESC
+        where: { tags_contains_all: $tag, unlisted: false }
+      ) {
         slug
         image {
           url


### PR DESCRIPTION
don't show unlisted blog posts on /blog so they
are only discoverable by URL.

blog index does not show new unlisted post
![image](https://user-images.githubusercontent.com/1351531/185262969-97be4e24-28af-4620-bfcb-418f9e848434.png)

[even though i can visit it directly](https://highlight-landing-git-vadim-hig-2594-add-d-645bbc-highlight-run.vercel.app/blog/scalable-data-processing-with-apache-kafka)
![image](https://user-images.githubusercontent.com/1351531/185262930-7643e2ef-23d2-4e32-8bac-f61346c4c412.png)
