### PR TITLE
fix(hig-2608): remove unnecessary spans and break up long urls

### DIFF
--- a/components/Blog/Blog.module.scss
+++ b/components/Blog/Blog.module.scss
@@ -269,9 +269,6 @@
     color: var(--color-secondary-200);
     font-weight: 600;
     text-decoration: none;
-  }
-
-  a span {
     word-break: break-all;
   }
 }

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -41,19 +41,11 @@ const getBlogTypographyRenderer = (type: string) => {
       if (content.code) {
         return <span className={styles.codeInline}>{content.text}</span>;
       } else if (content.italic) {
-        return (
-          <i>
-            <span>{content.text}</span>
-          </i>
-        );
+        return <i>{content.text}</i>;
       } else if (content.bold) {
-        return (
-          <b>
-            <span>{content.text}</span>
-          </b>
-        );
+        return <b>{content.text}</b>;
       }
-      return <span>{content.text}</span>;
+      return <>{content.text}</>;
     } else if (content.href) {
       return (
         <a
@@ -216,13 +208,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     });
   }
 
-  // for (const p of posts) {
-  //   if (!p.image?.url) {
-  //     throw new Error(
-  //       `missing required main image for blog '${p.slug}'. image: ${p.image?.url}`
-  //     );
-  //   }
-  // }
   if (!data.post.metaImage?.url || !data.post.author?.profilePhoto?.url) {
     throw new Error(
       `missing required detailed images for blog '${data.post.slug}'. 


### PR DESCRIPTION
Removes a lot of nested `<span>`s that we do not need and breaks up long URLs to avoid overflow.

Before

<img width="419" alt="Screen Shot 2022-08-19 at 1 24 10 PM" src="https://user-images.githubusercontent.com/17913919/185683238-8090b879-d282-46bd-8b80-ab4675452219.png">

After
<img width="429" alt="Screen Shot 2022-08-19 at 1 24 25 PM" src="https://user-images.githubusercontent.com/17913919/185683283-0fc913f3-8644-40a9-b322-97f3b1b10b2f.png">


 