### PR TITLE
allow rendering custom landing pages on subdomains

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 // this will redirect the domain landing page to the following page component
 const SUBDOMAIN_LANDING_PAGES = {
-  observability: '/blog',
+  observability: '/blog/frontend-observability',
 };
 
 export default function middleware(req: NextRequest) {


### PR DESCRIPTION
Until we have a new landing page for `observability`, configured the landing page to be the blog page.
![image](https://user-images.githubusercontent.com/1351531/188954096-c5dd60f2-bcf3-48b9-ac90-a4bede6c12b0.png)
Links continue to work correctly while the `/` landing page is rendered correctly for the subdomain.
Visiting the primary domain does not result in a custom landing page.
![image](https://user-images.githubusercontent.com/1351531/188954219-6ad4deaa-76d6-4460-8a71-6e1464d6a901.png)
