### PR TITLE
delay gql in prerendering to avoid too many concurrent requests

### DIFF
--- a/pages/api/og/blog/[slug].tsx
+++ b/pages/api/og/blog/[slug].tsx
@@ -4,7 +4,7 @@ import { gql } from 'graphql-request';
 import { Post } from '../../../../components/Blog/BlogPost/BlogPost';
 import { Buffer } from 'buffer';
 import { font, fontLight, hero } from '../util';
-import { GraphQLRequest } from '../../../util';
+import { GraphQLRequest } from '../../../../utils/graphql';
 
 export const config = {
   runtime: 'experimental-edge',

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -19,7 +19,7 @@ import { Post } from '../../components/Blog/BlogPost/BlogPost';
 import { Meta } from '../../components/common/Head/Meta';
 import { FaGithub, FaGlobe, FaLinkedin, FaTwitter } from 'react-icons/fa';
 import { HighlightCodeBlock } from '../../components/Docs/HighlightCodeBlock/HighlightCodeBlock';
-import { GraphQLRequest } from '../util';
+import { GraphQLRequest } from '../../utils/graphql';
 
 const NUM_SUGGESTED_POSTS = 3;
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { BlogPostSmall } from '../../components/Blog/BlogPostSmall/BlogPostSmall';
 import { Typography } from '../../components/common/Typography/Typography';
 import { Meta } from '../../components/common/Head/Meta';
-import { GraphQLRequest } from '../util';
+import { GraphQLRequest } from '../../utils/graphql';
 
 const ITEMS_PER_PAGE = 6;
 

--- a/pages/changelog/[slug].tsx
+++ b/pages/changelog/[slug].tsx
@@ -12,7 +12,7 @@ import { GetStaticPaths, GetStaticProps } from 'next/types';
 import { FooterCallToAction } from '../../components/common/CallToAction/FooterCallToAction';
 import ReactMarkdown from 'react-markdown';
 import { Meta } from '../../components/common/Head/Meta';
-import { GraphQLRequest } from '../util';
+import { GraphQLRequest } from '../../utils/graphql';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const QUERY = gql`

--- a/pages/changelog/index.tsx
+++ b/pages/changelog/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../components/Changelog/ChangelogEntry/ChangelogEntry';
 import { GetStaticProps } from 'next/types';
 import { Meta } from '../../components/common/Head/Meta';
-import { GraphQLRequest } from '../util';
+import { GraphQLRequest } from '../../utils/graphql';
 
 const ITEMS_PER_PAGE = 25;
 

--- a/pages/customers/[slug].tsx
+++ b/pages/customers/[slug].tsx
@@ -11,7 +11,7 @@ import { FooterCallToAction } from '../../components/common/CallToAction/FooterC
 import Footer from '../../components/common/Footer/Footer';
 import Navbar from '../../components/common/Navbar/Navbar';
 import ReturnIcon from '../../public/images/ReturnIcon';
-import { GraphQLRequest } from '../util';
+import { GraphQLRequest } from '../../utils/graphql';
 
 interface Customer {
   slug: string;

--- a/pages/customers/index.tsx
+++ b/pages/customers/index.tsx
@@ -8,7 +8,7 @@ import { Typography } from '../../components/common/Typography/Typography';
 import { PrimaryButton } from '../../components/common/Buttons/PrimaryButton';
 import { gql } from 'graphql-request';
 import { Author } from '../../components/Blog/BlogPost/BlogPost';
-import { GraphQLRequest } from '../util';
+import { GraphQLRequest } from '../../utils/graphql';
 
 interface Customer {
   slug: string;

--- a/utils/graphql.ts
+++ b/utils/graphql.ts
@@ -14,7 +14,7 @@ export const GraphQLRequest = async (
   variables?: Variables,
   delay: boolean = true
 ) => {
-  if (delay) {
+  if (process.env.NODE_ENV !== 'development' && delay) {
     // delay hygraph requests during prerendering to avoid too many concurrent requests
     await new Promise((r) => setTimeout(r, Math.random() * 1000));
   }


### PR DESCRIPTION
main builds have started failing because we are making too many hygraph requests all at once as part of the vercel prerendering
in SSG/ISR, delay the requests randomly to avoid being rate-limited

<img width="1499" alt="Screenshot 2022-10-25 at 4 30 27 PM" src="https://user-images.githubusercontent.com/1351531/197900903-9c701605-35f6-41b8-93b5-45b9456c832b.png">