### PR TITLE
remove references to deprecated metaImage

### DIFF
--- a/components/Blog/BlogPost/BlogPost.tsx
+++ b/components/Blog/BlogPost/BlogPost.tsx
@@ -1,5 +1,5 @@
 import styles from '../Blog.module.scss';
-import Image from "next/legacy/image";
+import Image from 'next/legacy/image';
 import Link from 'next/link';
 import { Typography } from '../../common/Typography/Typography';
 
@@ -19,9 +19,6 @@ export interface Post {
   description: string;
   metaDescription?: string;
   image?: {
-    url: string;
-  };
-  metaImage?: {
     url: string;
   };
   title: string;
@@ -44,21 +41,19 @@ export const BlogPost = ({
   slug,
   richcontent,
   image,
-  metaImage,
   title,
   publishedAt,
   tags,
   readingTime,
 }: Post) => {
   return (
-    (<Link href={`/blog/${slug}`} style={{ textDecoration: 'none' }}>
-
+    <Link href={`/blog/${slug}`} style={{ textDecoration: 'none' }}>
       <div className={styles.blogPost}>
         <div className={styles.cardSection}>
           <div className={styles.cardImage}>
-            {(image?.url || metaImage?.url) && (
+            {image?.url && (
               <Image
-                src={image?.url || metaImage?.url || ''}
+                src={image?.url || ''}
                 alt=""
                 layout="fill"
                 objectFit="cover"
@@ -80,7 +75,12 @@ export const BlogPost = ({
           <h3>{title}</h3>
           <div className={styles.tagDiv}>
             {tags.map((tag: string) => (
-              <Link key={tag} href={`/blog?tag=${tag}`} passHref={true} legacyBehavior>
+              <Link
+                key={tag}
+                href={`/blog?tag=${tag}`}
+                passHref={true}
+                legacyBehavior
+              >
                 <div>
                   <Typography type="copy3">{tag}</Typography>
                 </div>
@@ -89,7 +89,6 @@ export const BlogPost = ({
           </div>
         </div>
       </div>
-
-    </Link>)
+    </Link>
   );
 };

--- a/components/Blog/BlogPostSmall/BlogPostSmall.tsx
+++ b/components/Blog/BlogPostSmall/BlogPostSmall.tsx
@@ -1,5 +1,5 @@
 import styles from '../Blog.module.scss';
-import Image from "next/legacy/image";
+import Image from 'next/legacy/image';
 import Link from 'next/link';
 import { Post } from '../BlogPost/BlogPost';
 import { Typography } from '../../common/Typography/Typography';
@@ -7,7 +7,6 @@ import { Typography } from '../../common/Typography/Typography';
 export const BlogPostSmall = ({
   slug,
   image,
-  metaImage,
   title,
   publishedAt,
   tags,
@@ -16,11 +15,10 @@ export const BlogPostSmall = ({
   return (
     <div className={styles.blogPostSmall}>
       <Link href={`/blog/${slug}`} style={{ textDecoration: 'none' }}>
-
         <div className={styles.cardImage}>
-          {(image?.url || metaImage?.url) && (
+          {image?.url && (
             <Image
-              src={image?.url || metaImage?.url || ''}
+              src={image?.url || ''}
               alt=""
               layout="fill"
               objectFit="cover"
@@ -41,14 +39,18 @@ export const BlogPostSmall = ({
         </Typography>
         <div className={styles.tagDiv}>
           {tags.map((tag: string) => (
-            <Link key={tag} href={`/blog?tag=${tag}`} passHref={true} legacyBehavior>
+            <Link
+              key={tag}
+              href={`/blog?tag=${tag}`}
+              passHref={true}
+              legacyBehavior
+            >
               <div>
                 <Typography type="copy3">{tag}</Typography>
               </div>
             </Link>
           ))}
         </div>
-
       </Link>
     </div>
   );

--- a/components/Blog/SuggestedBlogPost/SuggestedBlogPost.tsx
+++ b/components/Blog/SuggestedBlogPost/SuggestedBlogPost.tsx
@@ -1,5 +1,5 @@
 import styles from '../Blog.module.scss';
-import Image from "next/legacy/image";
+import Image from 'next/legacy/image';
 import Link from 'next/link';
 import { Typography } from '../../common/Typography/Typography';
 import { Post } from '../BlogPost/BlogPost';
@@ -9,20 +9,18 @@ export const SuggestedBlogPost = ({
   slug,
   richcontent,
   image,
-  metaImage,
   title,
   publishedAt,
   tags,
   readingTime,
 }: Post) => {
   return (
-    (<Link href={`/blog/${slug}`} style={{ textDecoration: 'none' }}>
-
+    <Link href={`/blog/${slug}`} style={{ textDecoration: 'none' }}>
       <div className={classNames(styles.blogPost, styles.suggestedBlogPost)}>
         <div className={styles.cardSection}>
           <div className={styles.cardImage}>
             <Image
-              src={image?.url || metaImage?.url || ''}
+              src={image?.url || ''}
               alt=""
               layout="fill"
               objectFit="cover"
@@ -49,7 +47,12 @@ export const SuggestedBlogPost = ({
           </div>
           <div className={styles.tagDiv}>
             {tags.map((tag: string) => (
-              <Link key={tag} href={`/blog?tag=${tag}`} passHref={true} legacyBehavior>
+              <Link
+                key={tag}
+                href={`/blog?tag=${tag}`}
+                passHref={true}
+                legacyBehavior
+              >
                 <div>
                   <Typography type="copy3">{tag}</Typography>
                 </div>
@@ -58,7 +61,6 @@ export const SuggestedBlogPost = ({
           </div>
         </div>
       </div>
-
-    </Link>)
+    </Link>
   );
 };

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -43,9 +43,6 @@ export const loadPostsFromHygraph = async (tag: string | undefined) => {
               image {
                   url
               }
-              metaImage {
-                  url
-              }
               title
               publishedAt
               tags
@@ -102,55 +99,58 @@ export const Blog = ({
     Math.min(ITEMS_PER_PAGE * currentPage, posts.length)
   );
 
-  return <>
-    <Meta
-      title="Debugging Blog: Best Practices From The Highlight Team"
-      description="Get debugging best practices, read customer stories, and get general dev tips. Learn to stop debugging in the dark with Highlight's blog and featured articles."
-    />
-    <Navbar />
-    <main>
-      <div className={styles.blogContainer}>
-        <h4>Blog article of the week</h4>
-        <BlogPost {...posts[0]} />
-        <hr />
-      </div>
-      <div className={styles.tagContainer}>
-        <div className={styles.tagHeader}>
-          <h4 className={styles.tagSortTitle}>Sort by tag</h4>
-          <div className={styles.tagDiv}>
-            {tags.map((tag: string) => (
-              <Link
-                key={tag}
-                href={currentTag === tag ? '/blog' : `/blog/tag/${tag}`}
-                passHref={true}
-                legacyBehavior>
-                <div
-                  className={classNames({
-                    [styles.selectedTag]: currentTag === tag,
-                  })}
+  return (
+    <>
+      <Meta
+        title="Debugging Blog: Best Practices From The Highlight Team"
+        description="Get debugging best practices, read customer stories, and get general dev tips. Learn to stop debugging in the dark with Highlight's blog and featured articles."
+      />
+      <Navbar />
+      <main>
+        <div className={styles.blogContainer}>
+          <h4>Blog article of the week</h4>
+          <BlogPost {...posts[0]} />
+          <hr />
+        </div>
+        <div className={styles.tagContainer}>
+          <div className={styles.tagHeader}>
+            <h4 className={styles.tagSortTitle}>Sort by tag</h4>
+            <div className={styles.tagDiv}>
+              {tags.map((tag: string) => (
+                <Link
+                  key={tag}
+                  href={currentTag === tag ? '/blog' : `/blog/tag/${tag}`}
+                  passHref={true}
+                  legacyBehavior
                 >
-                  <Typography type="copy3">{tag}</Typography>
-                </div>
-              </Link>
-            ))}
+                  <div
+                    className={classNames({
+                      [styles.selectedTag]: currentTag === tag,
+                    })}
+                  >
+                    <Typography type="copy3">{tag}</Typography>
+                  </div>
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
-      <div className={styles.blogContainer}>
-        {currentItems.map((p: Post, i: number) => (
-          <BlogPostSmall {...p} key={i} />
-        ))}
-        <Paginate
-          currentPage={currentPage}
-          onPageChange={setCurrentPage}
-          pageRangeDisplayed={5}
-          pageCount={pageCount}
-        />
-      </div>
-      <FooterCallToAction />
-    </main>
-    <Footer />
-  </>;
+        <div className={styles.blogContainer}>
+          {currentItems.map((p: Post, i: number) => (
+            <BlogPostSmall {...p} key={i} />
+          ))}
+          <Paginate
+            currentPage={currentPage}
+            onPageChange={setCurrentPage}
+            pageRangeDisplayed={5}
+            pageCount={pageCount}
+          />
+        </div>
+        <FooterCallToAction />
+      </main>
+      <Footer />
+    </>
+  );
 };
 
 export default Blog;


### PR DESCRIPTION
No longer use the metaImage in the graphql queries for blog posts.
Instead, use the og image URLs in all places.