### PR TITLE
fixed footer links

### DIFF
--- a/components/common/Footer/Footer.tsx
+++ b/components/common/Footer/Footer.tsx
@@ -80,7 +80,7 @@ const Footer = () => {
               {Object.entries(PRODUCTS).map(([key, value]) => {
                 return (
                   <li key={value.docsLink}>
-                    <Link href={`for/${value.slug}`}>{value.title}</Link>
+                    <Link href={`/for/${value.slug}`}>{value.title}</Link>
                   </li>
                 )
               })}


### PR DESCRIPTION
Currently, the product links in the footer link to `for/${value.slug}`, which means that if you are currently on "for/express" and click on the react link, it will take you to "for/for/react". Added a "/" to always route to the right destination.