### PR TITLE
Second pass for pricing page v2

### DIFF
--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -354,6 +354,7 @@ const PriceCalculator = () => {
             value={loggingUsage}
             cost={loggingCost + basePrice}
             includedRange={0}
+            rangeMultiplier={100}
             onChange={setLoggingUsage}
           />
           <div className="block px-3 py-5 rounded-b-lg md:hidden">
@@ -376,6 +377,7 @@ const CalculatorRowDesktop = ({
   value,
   cost,
   includedRange,
+  rangeMultiplier = 1,
   onChange,
 }: {
   title: string
@@ -383,9 +385,12 @@ const CalculatorRowDesktop = ({
   value: number
   includedRange: number
   cost: number
+  rangeMultiplier?: number
   onChange: (value: number) => void
 }) => {
-  const rangeOptions = [0, 500, 1_000, 5_000, 10_000, 100_000, 250_000, 500_000, 750_000, 1_000_000]
+  const rangeOptions = [0, 500, 1_000, 5_000, 10_000, 100_000, 250_000, 500_000, 750_000, 1_000_000].map(
+    (v) => v * rangeMultiplier,
+  )
 
   return (
     <div className="flex flex-row">

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -292,8 +292,8 @@ const PriceCalculator = () => {
   const tier = priceTiers[tierName]
   const basePrice = getBasePrice(tier, billingPeriod, retention)
 
-  const getUsagePrice = (useage: number, price: number, size: number) =>
-    Math.trunc(((Math.max(useage, 0) * price) / size) * retentionMultipliers[retention] * 100) / 100
+  const getUsagePrice = (usage: number, price: number, size: number) =>
+    Math.trunc(((Math.max(usage, 0) * price) / size) * retentionMultipliers[retention] * 100) / 100
 
   const sessionsCost = getUsagePrice(sessionUsage - tier.sessions, 5.0, 1_000)
   const errorsCost = getUsagePrice(errorUsage - tier.errors, 0.2, 1_000)

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -22,7 +22,7 @@ import Wallet from '../../public/images/wallet.svg'
 import { RadioGroup } from '@headlessui/react'
 import * as Slider from '@radix-ui/react-slider'
 import classNames from 'classnames'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Collapsible from 'react-collapsible'
 import { Section } from '../../components/common/Section/Section'
 import { CompaniesReel } from '../../components/Home/CompaniesReel/CompaniesReel'
@@ -285,11 +285,17 @@ const PriceCalculator = () => {
   const [tierName, setTierName] = useState<TierName>('Free')
   const [retention, setRetention] = useState<Retention>('3 months')
 
-  const [errorUsage, setErrorUsage] = useState(50000)
-  const [sessionUsage, setSessionUsage] = useState(50000)
-  const [loggingUsage, setLoggingUsage] = useState(50000)
-
   const tier = priceTiers[tierName]
+
+  const [errorUsage, setErrorUsage] = useState(0)
+  const [sessionUsage, setSessionUsage] = useState(0)
+  const [loggingUsage, setLoggingUsage] = useState(0)
+
+  useEffect(() => {
+    setErrorUsage(tier.errors)
+    setSessionUsage(tier.sessions)
+  }, [tier, tierName])
+
   const basePrice = getBasePrice(tier, billingPeriod, retention)
 
   const getUsagePrice = (usage: number, price: number, size: number) =>
@@ -301,7 +307,6 @@ const PriceCalculator = () => {
 
   return (
     <div className="flex flex-col items-center w-full gap-10 mx-auto mt-12">
-      {' '}
       {/* Price calculator */}
       <div className="flex flex-wrap justify-center gap-12 gap-y-3">
         <RadioOptions

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -336,22 +336,25 @@ const PriceCalculator = () => {
             title="Error Monitoring Usage."
             description="Error monitoring usage is defined by the number of errors collected by Highlight per month. Our frontend/server SDKs send errors, but you can also send custom errors."
             value={errorUsage}
-            onChange={setErrorUsage}
             cost={errorsCost + basePrice}
+            includedRange={tier.errors}
+            onChange={setErrorUsage}
           />
           <CalculatorRowDesktop
             title="Session Replay Usage."
             description="Session replay usage is defined by the number of sessions collected per month. A session is defined by an instance of a user’s tab on your application. "
             value={sessionUsage}
-            onChange={setSessionUsage}
             cost={sessionsCost + basePrice}
+            includedRange={tier.sessions}
+            onChange={setSessionUsage}
           />
           <CalculatorRowDesktop
             title="Logging Usage."
             description="Log usage is defined by the number of logs collected by highlight.io per month. A log is defined by a text field with attributes."
             value={loggingUsage}
-            onChange={setLoggingUsage}
             cost={loggingCost + basePrice}
+            includedRange={0}
+            onChange={setLoggingUsage}
           />
           <div className="block px-3 py-5 rounded-b-lg md:hidden">
             <Typography type="copy1" emphasis>
@@ -371,14 +374,16 @@ const CalculatorRowDesktop = ({
   title,
   description,
   value,
-  onChange,
   cost,
+  includedRange,
+  onChange,
 }: {
   title: string
   description: string
   value: number
-  onChange: (value: number) => void
+  includedRange: number
   cost: number
+  onChange: (value: number) => void
 }) => {
   const rangeOptions = [0, 500, 1_000, 5_000, 10_000, 100_000, 250_000, 500_000, 750_000, 1_000_000]
 
@@ -398,7 +403,7 @@ const CalculatorRowDesktop = ({
         <Typography type="copy3" className="mt-2.5">
           {description}
         </Typography>
-        <RangedInput options={rangeOptions} value={value} onChange={onChange} />
+        <RangedInput options={rangeOptions} value={value} includedRange={includedRange} onChange={onChange} />
       </div>
       <div className="hidden border-l border-divider-on-dark md:inline-block">
         <CalculatorCostDisplay heading="Base + Usage" cost={cost} />
@@ -410,10 +415,12 @@ const CalculatorRowDesktop = ({
 export const RangedInput = ({
   options,
   value,
+  includedRange = 0,
   onChange,
 }: {
   options: number[]
   value: number
+  includedRange?: number
   onChange: (value: number) => void
 }) => {
   const sortedOptions = [...options].sort((a, b) => a - b)
@@ -461,8 +468,13 @@ export const RangedInput = ({
         onValueChange={([value]) => value != null && onChange(Math.ceil(denormalize(Math.pow(normalize(value), 3))))}
         className="relative items-center hidden w-full h-16 mt-4 select-none md:flex touch-none group"
       >
-        <Slider.Track className="relative flex-1 h-3 overflow-hidden rounded-full bg-divider-on-dark" />
-        <Slider.Thumb className="relative w-6 h-6 border-2 focus:border-purple-primary hover:shadow-white/25 hover:shadow-[0_0_0_4px] outline-none bg-[#F5F5F5] border-copy-on-dark rounded-full flex flex-col items-center transition-all">
+        <Slider.Track className="relative flex-1 h-3 overflow-hidden rounded-full bg-divider-on-dark">
+          <div
+            className="absolute inset-y-0 left-0 h-full bg-blue-cta/30"
+            style={{ width: `${Math.pow(normalize(includedRange), 1 / 3) * 100}%` }}
+          />
+        </Slider.Track>
+        <Slider.Thumb className="relative w-6 h-6 border-2 focus:border-blue-cta hover:shadow-white/25 hover:shadow-[0_0_0_4px] outline-none bg-[#F5F5F5] border-copy-on-dark rounded-full flex flex-col items-center transition-all">
           <div className="absolute w-2.5 h-2.5 rotate-45 rounded-sm -top-4 bg-blue-cta" />
           <div className="absolute px-1 py-0.5 mb-2 text-divider-on-dark font-semibold text-[10px] rounded-sm bottom-full bg-blue-cta">
             {value.toLocaleString(undefined, { notation: 'compact' })}

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon, InformationCircleIcon } from '@heroicons/react/20/solid'
 import { NextPage } from 'next'
 import Image from 'next/image'
 import { PrimaryButton } from '../../components/common/Buttons/PrimaryButton'
@@ -7,25 +8,24 @@ import Navbar from '../../components/common/Navbar/Navbar'
 import { Typography } from '../../components/common/Typography/Typography'
 import homeStyles from '../../components/Home/Home.module.scss'
 import pricingStyles from '../../components/Pricing/Pricing.module.scss'
-import { InformationCircleIcon, ChevronDownIcon, CheckIcon } from '@heroicons/react/20/solid'
 
-import PcPlayMedia from '../../public/images/pc-play-media.svg'
-import Wallet from '../../public/images/wallet.svg'
-import Stopwatch from '../../public/images/stopwatch.svg'
-import Globe from '../../public/images/globe.svg'
-import Security from '../../public/images/security.svg'
-import ReceiptList from '../../public/images/receipt-list.svg'
 import CreditCard from '../../public/images/credit-card.svg'
 import Delete from '../../public/images/delete.svg'
+import Globe from '../../public/images/globe.svg'
+import PcPlayMedia from '../../public/images/pc-play-media.svg'
+import ReceiptList from '../../public/images/receipt-list.svg'
+import Security from '../../public/images/security.svg'
+import Stopwatch from '../../public/images/stopwatch.svg'
 import TagLoyalty from '../../public/images/tag-loyalty.svg'
+import Wallet from '../../public/images/wallet.svg'
 
-import { RadioGroup, Listbox } from '@headlessui/react'
+import { RadioGroup } from '@headlessui/react'
 import * as Slider from '@radix-ui/react-slider'
-import { useState } from 'react'
 import classNames from 'classnames'
-import { CompaniesReel } from '../../components/Home/CompaniesReel/CompaniesReel'
+import { useState } from 'react'
 import Collapsible from 'react-collapsible'
 import { Section } from '../../components/common/Section/Section'
+import { CompaniesReel } from '../../components/Home/CompaniesReel/CompaniesReel'
 
 const PricingPage: NextPage = () => {
   return (
@@ -205,7 +205,6 @@ const PlanTable = () => {
 
   return (
     <div className="flex flex-col items-center max-w-full gap-6 mx-auto mt-16">
-      {' '}
       {/* Pricing */}
       <div className="flex flex-wrap justify-center gap-12 gap-y-3">
         <RadioOptions
@@ -260,8 +259,10 @@ const PlanTier = ({
         <div className="flex items-center gap-1">
           <Typography type="copy3" emphasis>
             Included
-          </Typography>{' '}
-          <InformationCircleIcon className="inline w-5 h-5" />
+          </Typography>
+          <a href="#overage" className="text-white transition-colors hover:text-blue-cta">
+            <InformationCircleIcon className="inline w-5 h-5" />
+          </a>
         </div>
         <Typography type="copy3">{sessions} monthly sessions</Typography>
         <Typography type="copy3">{errors} monthly errors</Typography>


### PR DESCRIPTION
Tweak the new pricing page with a few changes

- Move sliders on tier change, to maximum included quota
- Show area indicating included quota
- Change the range of logging slider to go up to 100m
- “Included” icon scrolls to “Pay as you go“