### PR TITLE
Fixed InitializeNodeSDK snippet in docs

### DIFF
--- a/components/QuickstartContent/backend/js/shared-snippets.tsx
+++ b/components/QuickstartContent/backend/js/shared-snippets.tsx
@@ -23,7 +23,7 @@ export const initializeNodeSDK: (slug: string) => QuickStartStep = (slug) => ({
   code: {
     text: `import { H } from '@highlight-run/${slug}'
 
-H.init({projectID: 'YOUR_PROJECT_ID')`,
+H.init({projectID: 'YOUR_PROJECT_ID'})`,
     language: 'js',
   },
 })


### PR DESCRIPTION
Smallest PR ever: Fixed a syntax error in the initializeNodeSDK snippet (added a close bracket)