### PR TITLE
Remove old initialization docs

### DIFF
--- a/components/QuickstartContent/frontend/angular.tsx
+++ b/components/QuickstartContent/frontend/angular.tsx
@@ -4,7 +4,6 @@ import {
   identifySnippet,
   initializeSnippet,
   packageInstallSnippet,
-  sessionReplayFeaturesLink,
   setupBackendSnippet,
   verifySnippet,
 } from './shared-snippets'
@@ -44,15 +43,6 @@ export const AngularContent: QuickStartContent = {
         ...initializeSnippet.code,
         text: angularInitCodeSnippet,
         language: initializeSnippet.code?.language ?? 'js',
-      },
-    },
-    {
-      title: 'Initialize the SDK in your frontend.',
-      content: `Grab your project ID from [app.highlight.io/setup](https://app.highlight.io/setup) and insert it in place of \`<YOUR_PROJECT_ID>\`.  
-                        To get started, we recommend setting \`environment\`, \`appVersion\`, and \`networkReco: inrding\`. Refer to our docs on [SDK configuration](${sessionReplayFeaturesLink}) to read more about these options. `,
-      code: {
-        text: angularInitCodeSnippet,
-        language: 'js',
       },
     },
     identifySnippet,


### PR DESCRIPTION
Removes a duplicate section in the Angular quickstart docs.

Resolves https://github.com/highlight/highlight/issues/4569.