### PR TITLE
Add missing properties for Ruby quickstart docs

### DIFF
--- a/components/QuickstartContent/QuickstartContent.tsx
+++ b/components/QuickstartContent/QuickstartContent.tsx
@@ -18,6 +18,8 @@ import { PythonFastAPIContext } from './backend/python/fastapi'
 import { PythonFlaskContext } from './backend/python/flask'
 import { PythonGCPContext } from './backend/python/gcp'
 import { PythonOtherContext } from './backend/python/other'
+import { RubyOtherContent } from './backend/ruby/other'
+import { RubyRailsContent } from './backend/ruby/rails'
 import { AngularContent } from './frontend/angular'
 import { GatsbyContent } from './frontend/gatsby'
 import { NextContent } from './frontend/next'
@@ -31,12 +33,10 @@ import { HTTPContent } from './logging/http'
 import { JSNestLogContent } from './logging/js/nestjs'
 import { JSOtherLogContent } from './logging/js/other'
 import { PythonOtherLogContent } from './logging/python/other'
-import { DevDeploymentContent } from './self-host/dev-deploy'
-import { SelfHostContent } from './self-host/self-host'
-import { RubyOtherContent } from './backend/ruby/other'
-import { RubyRailsContent } from './backend/ruby/rails'
 import { RubyOtherLogContent } from './logging/ruby/other'
 import { RubyRailsLogContent } from './logging/ruby/rails'
+import { DevDeploymentContent } from './self-host/dev-deploy'
+import { SelfHostContent } from './self-host/self-host'
 
 export type QuickStartContent = {
   title: string
@@ -91,7 +91,18 @@ export enum QuickStartType {
   RubyRails = 'rails',
 }
 
-export const quickStartContent = {
+export const quickStartContent: {
+  other: {
+    [key: string]: QuickStartContent
+  }
+} & {
+  [key: string]: {
+    title: string
+    subtitle: string
+  } & {
+    [key: string]: QuickStartContent
+  }
+} = {
   client: {
     title: 'Client SDKs',
     subtitle: 'Select a client SDK to get started.',
@@ -156,6 +167,9 @@ export const quickStartContent = {
       [QuickStartType.JStRPC]: JStRPCContent,
     },
     ruby: {
+      title: 'Ruby',
+      subtitle: 'Select your Ruby framework to install error monitoring for your application.',
+      logoUrl: siteUrl('/images/quickstart/ruby.svg'),
       [QuickStartType.RubyRails]: RubyRailsContent,
       [QuickStartType.RubyOther]: RubyOtherContent,
     },
@@ -189,6 +203,9 @@ export const quickStartContent = {
       [QuickStartType.HTTPOTLP]: HTTPContent,
     },
     ruby: {
+      title: 'Ruby',
+      subtitle: 'Select your Ruby framework to install logging in your application.',
+      logoUrl: siteUrl('/images/quickstart/ruby.svg'),
       [QuickStartType.RubyRails]: RubyRailsLogContent,
       [QuickStartType.RubyOther]: RubyOtherLogContent,
     },

--- a/components/QuickstartContent/backend/ruby/other.tsx
+++ b/components/QuickstartContent/backend/ruby/other.tsx
@@ -1,10 +1,12 @@
+import { siteUrl } from '../../../../utils/urls'
 import { QuickStartContent } from '../../QuickstartContent'
 import { frontendInstallSnippet } from '../shared-snippets'
-import { customError, installSdk, initializeSdk, setUpLogging, verifyErrors } from './shared-snippets'
+import { customError, initializeSdk, installSdk, setUpLogging, verifyErrors } from './shared-snippets'
 
 export const RubyOtherContent: QuickStartContent = {
   title: 'Ruby',
   subtitle: 'Learn how to set up highlight.io on your non-Rails Ruby backend.',
+  logoUrl: siteUrl('/images/quickstart/ruby.svg'),
   entries: [
     frontendInstallSnippet,
     installSdk,

--- a/components/QuickstartContent/backend/ruby/rails.tsx
+++ b/components/QuickstartContent/backend/ruby/rails.tsx
@@ -1,10 +1,12 @@
+import { siteUrl } from '../../../../utils/urls'
 import { QuickStartContent } from '../../QuickstartContent'
 import { frontendInstallSnippet } from '../shared-snippets'
-import { customError, installSdk, initializeSdk, setUpLogging } from './shared-snippets'
+import { customError, initializeSdk, installSdk, setUpLogging } from './shared-snippets'
 
 export const RubyRailsContent: QuickStartContent = {
   title: 'Rails',
   subtitle: 'Learn how to set up highlight.io on your Rails backend.',
+  logoUrl: siteUrl('/images/quickstart/rails.svg'),
   entries: [
     frontendInstallSnippet,
     installSdk,

--- a/components/QuickstartContent/logging/ruby/other.tsx
+++ b/components/QuickstartContent/logging/ruby/other.tsx
@@ -1,9 +1,11 @@
+import { siteUrl } from '../../../../utils/urls'
 import { QuickStartContent } from '../../QuickstartContent'
 import { previousInstallSnippet, verifyLogs } from '../shared-snippets'
 
 export const RubyOtherLogContent: QuickStartContent = {
   title: 'Ruby',
   subtitle: 'Learn how to set up highlight.io Ruby log ingestion.',
+  logoUrl: siteUrl('/images/quickstart/ruby.svg'),
   entries: [
     previousInstallSnippet('ruby'),
     {

--- a/components/QuickstartContent/logging/ruby/rails.tsx
+++ b/components/QuickstartContent/logging/ruby/rails.tsx
@@ -1,9 +1,11 @@
+import { siteUrl } from '../../../../utils/urls'
 import { QuickStartContent } from '../../QuickstartContent'
 import { previousInstallSnippet, verifyLogs } from '../shared-snippets'
 
 export const RubyRailsLogContent: QuickStartContent = {
   title: 'Rails',
   subtitle: 'Learn how to set up highlight.io Rails log ingestion.',
+  logoUrl: siteUrl('/images/quickstart/rails.svg'),
   entries: [
     previousInstallSnippet('ruby'),
     {

--- a/scripts/rudder-initialize.js
+++ b/scripts/rudder-initialize.js
@@ -12,8 +12,4 @@ export async function rudderInitialize() {
   rudderanalytics.load('2HMp4bSqggu0Z8W1cn6G5nydUxg', 'https://highlightwjh.dataplane.rudderstack.com', {
     integrations: { All: true }, // load call options
   })
-
-  rudderanalytics.ready(() => {
-    console.log('Rudderstack initialized!')
-  })
 }


### PR DESCRIPTION
Adds missing properties which are required for https://github.com/highlight/highlight/pull/4589. Also adds types to ensure we don't run into the issue again.